### PR TITLE
subscriberRegistry

### DIFF
--- a/Globals/Globals.cpp
+++ b/Globals/Globals.cpp
@@ -33,6 +33,7 @@ const char *gOpenWelcome =
 	"Copyright 2008, 2009, 2010 Free Software Foundation, Inc.\n"
 	"Copyright 2010 Kestrel Signal Processing, Inc.\n"
 	"Copyright 2011, 2012, 2013, 2014 Range Networks, Inc.\n"
+	"Reloaded for 2023 by FlUxIuS @ Penthertz SAS.\n"
 	"Release " VERSION " " PROD_CAT " formal build date " TIMESTAMP_ISO " " REPO_REV "\n"
 	"\"OpenBTS\" is a trademark of Range Networks, Inc.\n"
 	"\"OpenBTS-UMTS\" is a trademark of Range Networks, Inc.\n"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# OpenBTS-UMTS reloaded 2023
+# OpenBTS-UMTS reloaded 2024
 
-OpenBTS-UMTS reloaded for 2023. This fork extends changes from @EurecatSecurity make it compatiblee with latest UHD drivers, several fixes to work on Ubuntu 22.04.
+OpenBTS-UMTS reloaded for 2024. This fork extends changes from @EurecatSecurity make it compatiblee with latest UHD drivers, several fixes to work on Ubuntu 22.04.
 
 ## Compatible devices
 

--- a/README.md
+++ b/README.md
@@ -14,5 +14,12 @@ OpenBTS-UMTS reloaded for 2023. This fork extends changes from @EurecatSecurity 
 
 Refer to this wiki page for the new documentation: https://github.com/PentHertz/OpenBTS-UMTS/wiki
 
+## Docker images
+
+We are also providing a Docker images, so you will not to follow the installation instructions and run it straightfoward even if system dependencies are broken in the future (in theory!).
+
+Checkout the images there: https://hub.docker.com/r/penthertz/openbts-umts
+
+
 ##  Original notes from Range Networks (obsolete):  
 For information on supported hardware, and build, install, setup and run instructions see [the wiki page](http://openbts.org/w/index.php/OpenBTS-UMTS).

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ OpenBTS-UMTS reloaded for 2023. This fork extends changes from @EurecatSecurity 
   * X300/X310
   * N200/N210
   * USRP2
+* LimeSDR (experimental)
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,10 @@
-OpenBTS-UMTS reloaded 2023
-==========================
+# OpenBTS-UMTS reloaded 2023
 
 OpenBTS-UMTS reloaded. Compatibility with latest UHD drivers, several fixes and updated install documentation for ubuntu 22.04
 
-Original notes from Range Networks:  
+## Documentation
+
+Refer to this wiki page for the new documentation: https://github.com/PentHertz/OpenBTS-UMTS/wiki
+
+##  Original notes from Range Networks (obsolete):  
 For information on supported hardware, and build, install, setup and run instructions see [the wiki page](http://openbts.org/w/index.php/OpenBTS-UMTS).
-
-Notes for this fork:  
-You can run ./install_dependences.sh to get dependencies satisfied before installation.
-

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # OpenBTS-UMTS reloaded 2023
 
-OpenBTS-UMTS reloaded. Compatibility with latest UHD drivers, several fixes and updated install documentation for ubuntu 22.04
+OpenBTS-UMTS reloaded for 2023. This fork extends changes from @EurecatSecurity make it compatiblee with latest UHD drivers, several fixes to work on Ubuntu 22.04.
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,14 @@
 
 OpenBTS-UMTS reloaded for 2023. This fork extends changes from @EurecatSecurity make it compatiblee with latest UHD drivers, several fixes to work on Ubuntu 22.04.
 
+## Compatible devices
+
+* USRP
+  * B200/B210/B205-mini*
+  * X300/X310
+  * N200/N210
+  * USRP2
+
 ## Documentation
 
 Refer to this wiki page for the new documentation: https://github.com/PentHertz/OpenBTS-UMTS/wiki

--- a/TransceiverUHD/UHDDevice.cpp
+++ b/TransceiverUHD/UHDDevice.cpp
@@ -82,11 +82,12 @@ static struct uhd_dev_offset uhd_offsets[NUM_USRP_TYPES] = {
 	{ B2XX,  99 },
 	{ X300,  73 },
 	{ UMTRX, 0 },
+	{ LimeSDRUSB, 50 }, // picked from http://swigerco.com/UHDDevice.cpp.diff
 };
 
 static int get_dev_offset(enum uhd_dev_type type)
 {
-	if ((type != B2XX) && (type != USRP2) && (type != X300)) {
+	if ((type != B2XX) && (type != USRP2) && (type != X300) && (type != LimeSDRUSB)) {
 		LOG(ALERT) << "Unsupported device type";
 		return 0;
 	}
@@ -237,7 +238,7 @@ bool UHDDevice::parse_dev_type()
 {
         std::string mboard_str, dev_str;
         uhd::property_tree::sptr prop_tree;
-        size_t usrp2_str, b200_str, b210_str, x300_str, x310_str, b205mini_str;
+        size_t usrp2_str, b200_str, b210_str, x300_str, x310_str, b205mini_str, LimeSDRUSB_str;
 
         prop_tree = usrp_dev->get_device()->get_tree();
         dev_str = prop_tree->access<std::string>("/name").get();
@@ -249,6 +250,7 @@ bool UHDDevice::parse_dev_type()
         b210_str = mboard_str.find("B210");
         x300_str = mboard_str.find("X300");
         x310_str = mboard_str.find("X310");
+	LimeSDRUSB_str = mboard_str.find("LimeSDR-USB");
 
         if (b200_str != std::string::npos) {
                 dev_type = B2XX;
@@ -262,7 +264,9 @@ bool UHDDevice::parse_dev_type()
                 dev_type = X300;
         } else if (x310_str != std::string::npos) {
                 dev_type = X300;
-        } else {
+        } else if (LimeSDRUSB_str != std::string::npos) {
+		dev_type = LimeSDRUSB;
+ 	} else {
                 goto nosupport;
         }
 

--- a/TransceiverUHD/UHDDevice.cpp
+++ b/TransceiverUHD/UHDDevice.cpp
@@ -250,7 +250,7 @@ bool UHDDevice::parse_dev_type()
         b210_str = mboard_str.find("B210");
         x300_str = mboard_str.find("X300");
         x310_str = mboard_str.find("X310");
-	LimeSDRUSB_str = mboard_str.find("LimeSDR-USB");
+	LimeSDRUSB_str = mboard_str.find("LimeSDR");
 
         if (b200_str != std::string::npos) {
                 dev_type = B2XX;

--- a/TransceiverUHD/UHDDevice.h
+++ b/TransceiverUHD/UHDDevice.h
@@ -14,6 +14,7 @@ enum uhd_dev_type {
 	B2XX,
 	X300,
 	UMTRX,
+	LimeSDRUSB, // picked from http://swigerco.com/UHDDevice.h.diff
 	NUM_USRP_TYPES,
 };
 

--- a/configure.ac
+++ b/configure.ac
@@ -15,7 +15,7 @@ dnl See the LEGAL file in the main directory for details.
 dnl FIXME -- Need to add dependency check for asn1c.
 
 AC_PREREQ(2.57)
-AC_INIT(openbts-umts,1.0-master)
+AC_INIT(openbts-umts,1.1-master)
 
 AC_CANONICAL_BUILD
 AC_CANONICAL_HOST

--- a/install_dependences.sh
+++ b/install_dependences.sh
@@ -2,7 +2,7 @@
 # This script has been tested in Ubuntu 16.04 and 18.04. Please report any problem you find.
 
 # Install all package dependencies
-sudo apt install autoconf libtool build-essential libuhd-dev uhd-host libzmq3-dev libosip2-dev libortp-dev libusb-1.0-0-dev asn1c libtool-bin libsqlite3-dev libreadline-dev
+sudo apt-get install -y autoconf libtool build-essential libuhd-dev uhd-host libzmq3-dev libosip2-dev libortp-dev libusb-1.0-0-dev asn1c libtool-bin libsqlite3-dev libreadline-dev
 
 # Clone submodules from base repo
 git submodule init


### PR DESCRIPTION
Following this tutorial : https://umtrx.org/applications/openbts-umts/ it is better to run openbts-umts with subscriberRegistry
Any idea for installing this with ubuntu 22.04 : git clone https://github.com/RangeNetworks/subscriberRegistry.git ?


Chears,